### PR TITLE
IP base fix and puppet timeouts

### DIFF
--- a/couchbase_ubuntu_201_64/Vagrantfile
+++ b/couchbase_ubuntu_201_64/Vagrantfile
@@ -5,7 +5,7 @@ Vagrant.configure("2") do |config|
   num_nodes = 4
 
   # IP Address Base for private network
-  ip_addr_base = "192.168.56.%d"
+  ip_addr_base = "192.168.56.10%d"
 
   # Define Number of RAM for each node
   config.vm.provider :virtualbox do |v|

--- a/couchbase_ubuntu_201_64/manifests/default.pp
+++ b/couchbase_ubuntu_201_64/manifests/default.pp
@@ -2,12 +2,14 @@ exec { "couchbase-server-source":
     command => "/usr/bin/wget http://packages.couchbase.com/releases/2.0.1/couchbase-server-enterprise_x86_64_2.0.1.deb",
     cwd => "/home/vagrant/",
     creates => "/home/vagrant/couchbase-server-enterprise_x86_64_2.0.1.deb",
-    before => Package['couchbase-server']
+    before => Package['couchbase-server'],
+    timeout => 0
 }
 
 exec { "install-deps":
     command => "/usr/bin/apt-get install libssl0.9.8",
-    before => Package['couchbase-server']
+    before => Package['couchbase-server'],
+    timeout => 0
 }
 
 package { "couchbase-server":


### PR DESCRIPTION
192.168.56.1 is reserved for host machine. Also puppet can raise timeout errors on slow networks while fetching packages
